### PR TITLE
見出しがページ上に無いことを知らせるメッセージの追加

### DIFF
--- a/dist/js/main.js
+++ b/dist/js/main.js
@@ -17,9 +17,12 @@
   let renderingData = () => {
     return new Promise(resolve => {
       chrome.storage.local.get(currentTabName, data => {
-        data[currentTabName].forEach(heading => {
-          document.getElementById('headings').insertAdjacentHTML('beforeend', heading);
-        });
+        if (data[currentTabName].length > 0) {
+          document.getElementById('headings').children[0].remove();
+          data[currentTabName].forEach(heading => {
+            document.getElementById('headings').insertAdjacentHTML('beforeend', heading);
+          });
+        }
         return resolve();
       });
     });

--- a/dist/popup.html
+++ b/dist/popup.html
@@ -6,6 +6,7 @@
   </head>
   <body>
     <section id="headings">
+      <span>There's no heading.</span>
     </section>
     <script src="js/main.js"></script>
   </body>


### PR DESCRIPTION
デフォルトで、見出しがないことを知らせるメッセージを追加
抽出した見出しの数が1以上のとき、メッセージは消去される